### PR TITLE
✨ feat(URI): 宮崎県公式サイトにおける英語版ページのリンク先変更

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -273,6 +273,9 @@
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/us/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=en",
   "https://support.google.com/analytics/answer/6004245?hl=ja": "https://support.google.com/analytics/answer/6004245?hl=en",
+  "uri": {
+    "宮崎県新型コロナウイルス感染症関連情報": "https://www.pref.miyazaki.lg.jp/kohosenryaku/kenko/hoken/covid19_eng.html"
+  },
   "お問い合わせ先一覧": "List of contacts",
   "お問い合わせ内容": "Contents of inquiries",
   "局名": "Name of bureaus",

--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -263,6 +263,9 @@
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/jp/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=ja",
   "https://support.google.com/analytics/answer/6004245?hl=ja": "https://support.google.com/analytics/answer/6004245?hl=ja",
+  "uri": {
+    "宮崎県新型コロナウイルス感染症関連情報": "https://www.pref.miyazaki.lg.jp/kansensho-taisaku/kenko/hoken/covid19.html"
+  },
   "お問い合わせ先一覧": "お問い合わせ先一覧",
   "お問い合わせ内容": "お問い合わせ内容",
   "局名": "局名",

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -149,8 +149,7 @@ export default Vue.extend({
         },
         {
           title: this.$t('宮崎県新型コロナウイルス感染症関連情報'),
-          link:
-            'https://www.pref.miyazaki.lg.jp/kansensho-taisaku/kenko/hoken/covid19.html'
+          link: this.$t('uri.宮崎県新型コロナウイルス感染症関連情報').toString()
         },
         {
           title: this.$t('宮崎県主催イベント等の開催に関する基準'),


### PR DESCRIPTION


<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
close #74

## 📝 関連する issue / Related Issues
- #96 
- #98 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- 「宮崎県新型コロナウイルス感染症関連情報」リンク先を、英語版では別リンクを設定するように変更します。
- link 変数のstring型に合わせるため、 TranslateResult 型をstring型に変換する Object.prototype.toString() メソッドを利用します。
    - 詳細は、下記を参照してください。
    - [Object.prototype.toString() - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/toString)
- 日本語版、やさしい日本語版では、以前と同じリンク先に設定しています。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
なし

## 👀 確認したこと

旧プルリク状態 (#96) のブランチをローカル環境下で再現し、 `yarn dev` コマンドを実行したところ、下記と同様のエラーが発生しました。

[Merge pull request #96 from Morichan/ticket-74 · covid19-miyazaki/covid19@07a6682](https://github.com/covid19-miyazaki/covid19/runs/561846546?check_suite_focus=true)

```
ERROR in /home/runner/work/covid19/covid19/components/SideNavigation.vue(152,11):
152:11 Type 'TranslateResult' is not assignable to type 'string'.
  Type 'LocaleMessages' is not assignable to type 'string'.
    150 |         {
    151 |           title: this.$t('宮崎県新型コロナウイルス感染症関連情報'),
  > 152 |           link: this.$t('uri.宮崎県新型コロナウイルス感染症関連情報')
        |           ^
    153 |         },
    154 |         {
    155 |           title: this.$t('宮崎県主催イベント等の開催に関する基準'),

 FATAL  Nuxt build error

  at WebpackBundler.webpackCompile (node_modules/@nuxt/webpack/dist/webpack.js:5326:21)
  at process._tickCallback (internal/process/next_tick.js:68:7)
```

そこで、string型に変換する `toString()` メソッドを利用し、string型に変換させ、ローカル上ではエラーが出ないことを確認しました。

## 🙇‍♀ 謝罪

適当なプルリクを投げてしまい、誠に申し訳ございませんでした！