### PR TITLE
陽性患者数グラフにおける前日比が異なるのを修正 Fix #182

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -250,6 +250,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: false
               },
+              offset: true,
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -163,6 +163,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayTransitionRatio() {
       const lastDay = this.chartData.slice(-1)[0].transition
       const lastDayBefore = this.chartData.slice(-2)[0].transition
+      const lastDayLabel = this.chartData.slice(-1)[0].label
+      const lastDayBeforeLabel = this.chartData.slice(-2)[0].label
+      const lastDayDate = new Date(lastDayLabel).getTime()
+      const lastDayBeforeDate = new Date(lastDayBeforeLabel).getTime()
+
+      // 1日以上差があるということは昨日はゼロ件なのでゼロと比較する必要あり（86,400,000ミリ秒＝１日）
+      const dateDiff = (lastDayDate - lastDayBeforeDate) / 86400000
+      if (dateDiff > 1) return this.formatDayBeforeRatio(lastDay - 0)
+
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayInfo() {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -165,11 +165,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const lastDayBefore = this.chartData.slice(-2)[0].transition
       const lastDayLabel = this.chartData.slice(-1)[0].label
       const lastDayBeforeLabel = this.chartData.slice(-2)[0].label
-      const lastDayDate = new Date(lastDayLabel).getTime()
-      const lastDayBeforeDate = new Date(lastDayBeforeLabel).getTime()
+      const lastDayTime = new Date(lastDayLabel).getTime()
+      const lastDayBeforeTime = new Date(lastDayBeforeLabel).getTime()
 
       // 1日以上差があるということは昨日はゼロ件なのでゼロと比較する必要あり（86,400,000ミリ秒＝１日）
-      const dateDiff = (lastDayDate - lastDayBeforeDate) / 86400000
+      const dateDiff = (lastDayTime - lastDayBeforeTime) / 86400000
       if (dateDiff > 1) return this.formatDayBeforeRatio(lastDay - 0)
 
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #182 


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
 「以前に1人以上陽性患者が存在した日」との比較
ではなく
前日と比較するように修正しました

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
before | after
---- | ----
<img src="https://user-images.githubusercontent.com/893643/80276041-a7ac1f80-8720-11ea-9d1a-693c8afd1d48.png" width="320"/> | <img src="https://user-images.githubusercontent.com/893643/80276043-aa0e7980-8720-11ea-9e33-b1a7a6c10f57.png" width="320"/>
