### PR TITLE
Closed: #214 宮崎県の「緊急事態宣言」についてのリンクを追加

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,6 +12,17 @@
         <t-i18n>{{ $t('注釈') }}</t-i18n>
       </div>
     </div>
+    <static-info
+      class="mb-4"
+      :url="
+        'https://www.pref.miyazaki.lg.jp/kansensho-taisaku/kenko/hoken/kinkyujitaisengen_covid19.html'
+      "
+      :text="
+        $t(
+          '「緊急事態宣言」が全国一律で5月末まで延長され、また国の基本的対処方針が改定されました'
+        )
+      "
+    />
     <whats-new class="mb-4" :items="newsItems" />
     <static-info
       class="mb-4"


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #214 


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 画面上部に宮崎県の『「緊急事態宣言」が全国一律で5月末まで延長され、また国の基本的対処方針が改定されました』というページのリンクを追加


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

![スクリーンショット 2020-05-10 20 46 36](https://user-images.githubusercontent.com/45593212/81500731-040d6280-930f-11ea-9529-1dbc29e8bc89.png)
↓
![スクリーンショット 2020-05-10 22 30 56](https://user-images.githubusercontent.com/45593212/81500738-05d72600-930f-11ea-8676-93cee9886096.png)





