### PR TITLE
closed #286 fix: workflow works even if the news isn't updated

### DIFF
--- a/.github/workflows/news_scraping.yml
+++ b/.github/workflows/news_scraping.yml
@@ -39,9 +39,7 @@ jobs:
         title: '最新のお知らせ更新'
         body: '公式サイトのお知らせが更新されました。差分を確認してマージしてください。'
         token: ${{ secrets.BOT_TOKEN }}
-    # ここから下はお知らせに差分があった場合のみ実行する
     - uses: actions/checkout@v2
-      if: steps.cpr.outputs.pr_number != 0
     - name: Scraping Data
       env:
         URL: "https://www.pref.miyazaki.lg.jp/kansensho-taisaku/covid-19/hassei_list.html"
@@ -49,16 +47,14 @@ jobs:
         TZ: Asia/Tokyo
       run: |
         ruby scrapingSource/scraping_data.rb
-      if: steps.cpr.outputs.pr_number != 0
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v2
       with:
         commit-message: 'Update data.json'
         branch: data
         base: master
-        # labels: auto_merge
+        labels: auto_merge
         branch-suffix: timestamp
         title: '陽性患者数更新'
         body: '公式サイトの情報が更新されました。差分を確認してマージしてください。'
         token: ${{ secrets.BOT_TOKEN }}
-      if: steps.cpr.outputs.pr_number != 0


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #286 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- newsに更新がなくても、陽性者数を更新するようにした
- auto_mergeするようにした

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
